### PR TITLE
VcRedist `14.30.30704.0`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,17 +2,18 @@
     "cSpell.words": [
         "Bitness",
         "GUIDs",
-        "Runtimes",
-        "Snapins",
-        "VcRedist",
         "installedvcredist",
+        "MAML",
         "noreboot",
         "robocopy",
+        "Runtimes",
+        "Snapins",
         "vcconfigmgrapplication",
         "vcintuneapplication",
         "vclist",
         "vcmanifest",
         "vcmdtapplication",
-        "vcmdtbundle"
+        "vcmdtbundle",
+        "VcRedist"
     ]
 }

--- a/VcRedist/Public/Get-VcList.ps1
+++ b/VcRedist/Public/Get-VcList.ps1
@@ -7,7 +7,7 @@ Function Get-VcList {
     Param (
         [Parameter(Mandatory = $False, Position = 0, ParameterSetName = "Manifest")]
         [ValidateSet("2005", "2008", "2010", "2012", "2013", "2015", "2017", "2019", "2022")]
-        [System.String[]] $Release = @("2010", "2012", "2013", "2019", "2022"),
+        [System.String[]] $Release = @("2012", "2013", "2022"),
 
         [Parameter(Mandatory = $False, Position = 1, ParameterSetName = "Manifest")]
         [ValidateSet("x86", "x64")]

--- a/VcRedist/Public/Get-VcList.ps1
+++ b/VcRedist/Public/Get-VcList.ps1
@@ -3,24 +3,24 @@ Function Get-VcList {
         .EXTERNALHELP VcRedist-help.xml
     #>
     [OutputType([System.Management.Automation.PSObject])]
-    [CmdletBinding(DefaultParameterSetName = 'Manifest', HelpURI = "https://stealthpuppy.com/vcredist/get-vclist/")]
+    [CmdletBinding(DefaultParameterSetName = "Manifest", HelpURI = "https://stealthpuppy.com/vcredist/get-vclist/")]
     Param (
-        [Parameter(Mandatory = $False, Position = 0, ParameterSetName = 'Manifest')]
-        [ValidateSet('2005', '2008', '2010', '2012', '2013', '2015', '2017', '2019')]
-        [System.String[]] $Release = @("2010", "2012", "2013", "2019"),
+        [Parameter(Mandatory = $False, Position = 0, ParameterSetName = "Manifest")]
+        [ValidateSet("2005", "2008", "2010", "2012", "2013", "2015", "2017", "2019", "2022")]
+        [System.String[]] $Release = @("2010", "2012", "2013", "2019", "2022"),
 
-        [Parameter(Mandatory = $False, Position = 1, ParameterSetName = 'Manifest')]
-        [ValidateSet('x86', 'x64')]
+        [Parameter(Mandatory = $False, Position = 1, ParameterSetName = "Manifest")]
+        [ValidateSet("x86", "x64")]
         [System.String[]] $Architecture = @("x86", "x64"),
 
-        [Parameter(Mandatory = $False, Position = 2, ValueFromPipeline, ParameterSetName = 'Manifest')]
+        [Parameter(Mandatory = $False, Position = 2, ValueFromPipeline, ParameterSetName = "Manifest")]
         [ValidateNotNull()]
-        [ValidateScript( { If (Test-Path -Path $_ -PathType 'Leaf' -ErrorAction "SilentlyContinue") { $True } Else { Throw "Cannot find file $_" } })]
+        [ValidateScript( { If (Test-Path -Path $_ -PathType "Leaf" -ErrorAction "SilentlyContinue") { $True } Else { Throw "Cannot find file $_" } })]
         [Alias("Xml")]
         [System.String] $Path = (Join-Path -Path $MyInvocation.MyCommand.Module.ModuleBase -ChildPath "VisualCRedistributables.json"),
 
-        [Parameter(Mandatory = $False, Position = 0, ParameterSetName = 'Export')]
-        [ValidateSet('Supported', 'All', 'Unsupported')]
+        [Parameter(Mandatory = $False, Position = 0, ParameterSetName = "Export")]
+        [ValidateSet("Supported", "All", "Unsupported")]
         [System.String] $Export = "Supported"
     )
 
@@ -44,7 +44,7 @@ Function Get-VcList {
         }
 
         If ($Null -ne $json) {
-            If ($PSBoundParameters.ContainsKey('Export')) {
+            If ($PSBoundParameters.ContainsKey("Export")) {
                 Switch ($Export) {
                     "Supported" {
                         Write-Verbose -Message "$($MyInvocation.MyCommand): Exporting supported VcRedists."

--- a/VcRedist/Public/Uninstall-VcRedist.ps1
+++ b/VcRedist/Public/Uninstall-VcRedist.ps1
@@ -9,8 +9,8 @@ Function Uninstall-VcRedist {
     [CmdletBinding()]
     Param (
         [Parameter(Mandatory = $False, Position = 0, ParameterSetName = 'Manual')]
-        [ValidateSet("2005", "2008", "2010", "2012", "2013", "2015", "2017", "2019")]
-        [System.String[]] $Release = @("2005", "2008", "2010", "2012", "2013", "2015", "2017", "2019"),
+        [ValidateSet("2005", "2008", "2010", "2012", "2013", "2015", "2017", "2019", "2022")]
+        [System.String[]] $Release = @("2005", "2008", "2010", "2012", "2013", "2015", "2017", "2019", "2022"),
 
         [Parameter(Mandatory = $False, Position = 1, ParameterSetName = 'Manual')]
         [ValidateSet("x86", "x64")]

--- a/VcRedist/VisualCRedistributables.json
+++ b/VcRedist/VisualCRedistributables.json
@@ -1,32 +1,6 @@
 {
     "Supported":  [
                       {
-                          "Name":  "Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update",
-                          "ProductCode":  "{1D8E6291-B0D5-35EC-8441-6616F567A0F7}",
-                          "Version":  "10.0.40219.325",
-                          "URL":  "https://www.microsoft.com/en-us/download/details.aspx?id=26999",
-                          "Download":  "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe",
-                          "Release":  "2010",
-                          "Architecture":  "x64",
-                          "Install":  "/passive /norestart",
-                          "SilentInstall":  "/quiet /norestart",
-                          "SilentUninstall":  "MsiExec.exe /X#ProductCode /QB-",
-                          "UninstallKey":  "64"
-                      },
-                      {
-                          "Name":  "Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update",
-                          "ProductCode":  "{F0C3E5D1-1ADE-321E-8167-68EF0DE699A5}",
-                          "Version":  "10.0.40219.325",
-                          "URL":  "https://www.microsoft.com/en-us/download/details.aspx?id=26999",
-                          "Download":  "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe",
-                          "Release":  "2010",
-                          "Architecture":  "x86",
-                          "Install":  "/passive /norestart",
-                          "SilentInstall":  "/quiet /norestart",
-                          "SilentUninstall":  "MsiExec.exe /X#ProductCode /QB-",
-                          "UninstallKey":  "32"
-                      },
-                      {
                           "Name":  "Visual C++ Redistributable for Visual Studio 2012 Update 4",
                           "ProductCode":  "{ca67548a-5ebe-413a-b50c-4b9ceb6d66c6}",
                           "Version":  "11.0.61030.0",
@@ -415,6 +389,32 @@
                             "Architecture":  "x86",
                             "Install":  "/Q",
                             "SilentInstall":  "/Q",
+                            "SilentUninstall":  "MsiExec.exe /X#ProductCode /QB-",
+                            "UninstallKey":  "32"
+                        },
+                        {
+                            "Name":  "Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update",
+                            "ProductCode":  "{1D8E6291-B0D5-35EC-8441-6616F567A0F7}",
+                            "Version":  "10.0.40219.325",
+                            "URL":  "https://www.microsoft.com/en-us/download/details.aspx?id=26999",
+                            "Download":  "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x64.exe",
+                            "Release":  "2010",
+                            "Architecture":  "x64",
+                            "Install":  "/passive /norestart",
+                            "SilentInstall":  "/quiet /norestart",
+                            "SilentUninstall":  "MsiExec.exe /X#ProductCode /QB-",
+                            "UninstallKey":  "64"
+                        },
+                        {
+                            "Name":  "Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update",
+                            "ProductCode":  "{F0C3E5D1-1ADE-321E-8167-68EF0DE699A5}",
+                            "Version":  "10.0.40219.325",
+                            "URL":  "https://www.microsoft.com/en-us/download/details.aspx?id=26999",
+                            "Download":  "https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe",
+                            "Release":  "2010",
+                            "Architecture":  "x86",
+                            "Install":  "/passive /norestart",
+                            "SilentInstall":  "/quiet /norestart",
                             "SilentUninstall":  "MsiExec.exe /X#ProductCode /QB-",
                             "UninstallKey":  "32"
                         },

--- a/VcRedist/VisualCRedistributables.json
+++ b/VcRedist/VisualCRedistributables.json
@@ -129,7 +129,33 @@
                           "SilentInstall":  "/install /quiet /norestart",
                           "SilentUninstall":  "\"%ProgramData%\\Package Cache\\#ProductCode\\#Installer\" /uninstall /quiet /noreboot",
                           "UninstallKey":  "32"
-                      }
+                      },
+                      {
+                        "Name":  "Visual C++ Redistributable for Visual Studio 2022",
+                        "ProductCode":  "{fa7f6d52-f85e-48ef-8f56-a37268aa5773}",
+                        "Version":  "14.30.30135.0",
+                        "URL":  "https://www.visualstudio.com/downloads/",
+                        "Download":  "https://aka.ms/vs/17/release/VC_redist.x64.exe",
+                        "Release":  "2022",
+                        "Architecture":  "x64",
+                        "Install":  "/install /passive /norestart",
+                        "SilentInstall":  "/install /quiet /norestart",
+                        "SilentUninstall":  "\"%ProgramData%\\Package Cache\\#ProductCode\\#Installer\" /uninstall /quiet /noreboot",
+                        "UninstallKey":  "32"
+                    },
+                    {
+                        "Name":  "Visual C++ Redistributable for Visual Studio 2019",
+                        "ProductCode":  "{b7a2b241-3f54-4d7d-94d1-8ce0146e03c8}",
+                        "Version":  "14.30.30135.0",
+                        "URL":  "https://www.visualstudio.com/downloads/",
+                        "Download":  "https://aka.ms/vs/17/release/VC_redist.x86.exe",
+                        "Release":  "2022",
+                        "Architecture":  "x86",
+                        "Install":  "/install /passive /norestart",
+                        "SilentInstall":  "/install /quiet /norestart",
+                        "SilentUninstall":  "\"%ProgramData%\\Package Cache\\#ProductCode\\#Installer\" /uninstall /quiet /noreboot",
+                        "UninstallKey":  "32"
+                    }
                   ],
     "Unsupported":  [
                         {

--- a/VcRedist/VisualCRedistributables.json
+++ b/VcRedist/VisualCRedistributables.json
@@ -131,31 +131,31 @@
                           "UninstallKey":  "32"
                       },
                       {
-                        "Name":  "Visual C++ Redistributable for Visual Studio 2022",
-                        "ProductCode":  "{fa7f6d52-f85e-48ef-8f56-a37268aa5773}",
-                        "Version":  "14.30.30000.0",
-                        "URL":  "https://www.visualstudio.com/downloads/",
-                        "Download":  "https://aka.ms/vs/17/release/VC_redist.x64.exe",
-                        "Release":  "2022",
-                        "Architecture":  "x64",
-                        "Install":  "/install /passive /norestart",
-                        "SilentInstall":  "/install /quiet /norestart",
-                        "SilentUninstall":  "\"%ProgramData%\\Package Cache\\#ProductCode\\#Installer\" /uninstall /quiet /noreboot",
-                        "UninstallKey":  "32"
-                    },
-                    {
-                        "Name":  "Visual C++ Redistributable for Visual Studio 2019",
-                        "ProductCode":  "{b7a2b241-3f54-4d7d-94d1-8ce0146e03c8}",
-                        "Version":  "14.30.30000.0",
-                        "URL":  "https://www.visualstudio.com/downloads/",
-                        "Download":  "https://aka.ms/vs/17/release/VC_redist.x86.exe",
-                        "Release":  "2022",
-                        "Architecture":  "x86",
-                        "Install":  "/install /passive /norestart",
-                        "SilentInstall":  "/install /quiet /norestart",
-                        "SilentUninstall":  "\"%ProgramData%\\Package Cache\\#ProductCode\\#Installer\" /uninstall /quiet /noreboot",
-                        "UninstallKey":  "32"
-                    }
+                          "Name":  "Visual C++ Redistributable for Visual Studio 2022",
+                          "ProductCode":  "{57a73df6-4ba9-4c1d-bbbb-517289ff6c13}",
+                          "Version":  "14.30.30704.0",
+                          "URL":  "https://www.visualstudio.com/downloads/",
+                          "Download":  "https://aka.ms/vs/17/release/VC_redist.x64.exe",
+                          "Release":  "2022",
+                          "Architecture":  "x64",
+                          "Install":  "/install /passive /norestart",
+                          "SilentInstall":  "/install /quiet /norestart",
+                          "SilentUninstall":  "\"%ProgramData%\\Package Cache\\#ProductCode\\#Installer\" /uninstall /quiet /noreboot",
+                          "UninstallKey":  "32"
+                      },
+                      {
+                          "Name":  "Visual C++ Redistributable for Visual Studio 2019",
+                          "ProductCode":  "{4d8dcf8c-a72a-43e1-9833-c12724db736e}",
+                          "Version":  "14.30.30704.0",
+                          "URL":  "https://www.visualstudio.com/downloads/",
+                          "Download":  "https://aka.ms/vs/17/release/VC_redist.x86.exe",
+                          "Release":  "2022",
+                          "Architecture":  "x86",
+                          "Install":  "/install /passive /norestart",
+                          "SilentInstall":  "/install /quiet /norestart",
+                          "SilentUninstall":  "\"%ProgramData%\\Package Cache\\#ProductCode\\#Installer\" /uninstall /quiet /noreboot",
+                          "UninstallKey":  "32"
+                      }
                   ],
     "Unsupported":  [
                         {

--- a/VcRedist/VisualCRedistributables.json
+++ b/VcRedist/VisualCRedistributables.json
@@ -144,7 +144,7 @@
                           "UninstallKey":  "32"
                       },
                       {
-                          "Name":  "Visual C++ Redistributable for Visual Studio 2019",
+                          "Name":  "Visual C++ Redistributable for Visual Studio 2022",
                           "ProductCode":  "{4d8dcf8c-a72a-43e1-9833-c12724db736e}",
                           "Version":  "14.30.30704.0",
                           "URL":  "https://www.visualstudio.com/downloads/",

--- a/VcRedist/VisualCRedistributables.json
+++ b/VcRedist/VisualCRedistributables.json
@@ -133,7 +133,7 @@
                       {
                         "Name":  "Visual C++ Redistributable for Visual Studio 2022",
                         "ProductCode":  "{fa7f6d52-f85e-48ef-8f56-a37268aa5773}",
-                        "Version":  "14.30.30135.0",
+                        "Version":  "14.30.30704.0",
                         "URL":  "https://www.visualstudio.com/downloads/",
                         "Download":  "https://aka.ms/vs/17/release/VC_redist.x64.exe",
                         "Release":  "2022",
@@ -146,7 +146,7 @@
                     {
                         "Name":  "Visual C++ Redistributable for Visual Studio 2019",
                         "ProductCode":  "{b7a2b241-3f54-4d7d-94d1-8ce0146e03c8}",
-                        "Version":  "14.30.30135.0",
+                        "Version":  "14.30.30704.0",
                         "URL":  "https://www.visualstudio.com/downloads/",
                         "Download":  "https://aka.ms/vs/17/release/VC_redist.x86.exe",
                         "Release":  "2022",

--- a/VcRedist/VisualCRedistributables.json
+++ b/VcRedist/VisualCRedistributables.json
@@ -133,7 +133,7 @@
                       {
                         "Name":  "Visual C++ Redistributable for Visual Studio 2022",
                         "ProductCode":  "{fa7f6d52-f85e-48ef-8f56-a37268aa5773}",
-                        "Version":  "14.30.30704.0",
+                        "Version":  "14.30.30000.0",
                         "URL":  "https://www.visualstudio.com/downloads/",
                         "Download":  "https://aka.ms/vs/17/release/VC_redist.x64.exe",
                         "Release":  "2022",
@@ -146,7 +146,7 @@
                     {
                         "Name":  "Visual C++ Redistributable for Visual Studio 2019",
                         "ProductCode":  "{b7a2b241-3f54-4d7d-94d1-8ce0146e03c8}",
-                        "Version":  "14.30.30704.0",
+                        "Version":  "14.30.30000.0",
                         "URL":  "https://www.visualstudio.com/downloads/",
                         "Download":  "https://aka.ms/vs/17/release/VC_redist.x86.exe",
                         "Release":  "2022",

--- a/ci/Update-Manifest.ps1
+++ b/ci/Update-Manifest.ps1
@@ -4,10 +4,10 @@
 #>
 [OutputType()]
 Param (
-    $Release = "2019"
+    $Release = "2022"
 )
 
-# Get an array of VcRedists from the curernt manifest and the installed VcRedists
+# Get an array of VcRedists from the current manifest and the installed VcRedists
 Write-Host " "
 Write-Host -ForegroundColor Cyan "`tGetting manifest from: $VcManifest."
 $CurrentManifest = Get-Content -Path $VcManifest | ConvertFrom-Json

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## VERSION
+
+* Moves the `Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update` to the unsupported list of Redistributables
+
 ## 3.0.281
 
 * Update for VcRedist 2019 version `14.29.30135.0`
@@ -10,7 +14,7 @@
 * Fixes an issue with `Import-VcConfigMgrApplication` that produces an error `String was not recognized as a valid DateTime`. Function now uses the short date/time format of the current session when importing the application
 * Updated `New-VcMdtBundle` and `Update-VcMdtBundle` to use the short date/time format of the current session when creating or updating the bundle
 
-## 3.0.273
+## 3.0.271
 
 * Update for VcRedist 2019 version `14.29.30040.0`
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,7 @@
 
 ## VERSION
 
+* Adds support for Visual C++ Redistributable for Visual Studio 2022, version `14.30.30704.0`
 * Moves the `Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update` to the unsupported list of Redistributables
 
 ## 3.0.281

--- a/docs/get-vclist.md
+++ b/docs/get-vclist.md
@@ -2,12 +2,36 @@
 
 `Get-VcList` returns the list of Visual C++ Redistributables. The VcRedist module includes the full list of available supported and unsupported  Redistributables and returns only the supported list by default. Unless you have a specific requirement, it is highly recommend that you install only [the supported Redistributables](https://support.microsoft.com/en-au/help/2977003/the-latest-supported-visual-c-downloads).
 
-Running `Get-VcList` with no parameters will return an array of the supported Redistributables by reading the internal manifest. Output can then be manipulated to filter the results. Note though, the default behaviour of `Get-VcList` is currently to return only the 2010, 2012, 2013 and 2019 Redistributables. This is because the 2015, 2017 and 2019 Redistributables are all the same major version and will be upgraded to the 2019 release and can't be installed side-by-side.
+Running `Get-VcList` with no parameters will return an array of the supported Redistributables by reading the internal manifest. Output can then be manipulated to filter the results. Note though, the default behaviour of `Get-VcList` is currently to return only the 2012, 2013 and 2022 Redistributables. This is because the 2015, 2017, 2019 and 2022 Redistributables are all the same major version and will be upgraded to the 2022 release and can't be installed side-by-side.
 
 Here's a sample of what's returned:
 
 ```powershell
 PS C:\> Get-VcList
+
+Name            : Visual C++ Redistributable for Visual Studio 2012 Update 4
+ProductCode     : {ca67548a-5ebe-413a-b50c-4b9ceb6d66c6}
+Version         : 11.0.61030.0
+URL             : https://www.microsoft.com/en-us/download/details.aspx?id=30679
+Download        : https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
+Release         : 2012
+Architecture    : x64
+Install         : /install /passive /norestart
+SilentInstall   : /quiet /norestart
+SilentUninstall : "%ProgramData%\Package Cache\{ca67548a-5ebe-413a-b50c-4b9ceb6d66c6}\vcredist_x64.exe" /uninstall /quiet /noreboot
+UninstallKey    : 32
+
+Name            : Visual C++ Redistributable for Visual Studio 2012 Update 4
+ProductCode     : {33d1fd90-4274-48a1-9bc1-97e33d9c2d6f}
+Version         : 11.0.61030.0
+URL             : https://www.microsoft.com/en-us/download/details.aspx?id=30679
+Download        : https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe
+Release         : 2012
+Architecture    : x86
+Install         : /install /passive /norestart
+SilentInstall   : /install /quiet /norestart
+SilentUninstall : "%ProgramData%\Package Cache\{33d1fd90-4274-48a1-9bc1-97e33d9c2d6f}\vcredist_x86.exe" /uninstall /quiet /noreboot
+UninstallKey    : 32
 
 Name            : Visual C++ 2013 Update 5 Redistributable Package
 ProductCode     : {042d26ef-3dbe-4c25-95d3-4c1b11b235a7}
@@ -33,28 +57,28 @@ SilentInstall   : /install /quiet /norestart
 SilentUninstall : "%ProgramData%\Package Cache\{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}\vcredist_x86.exe" /uninstall /quiet /noreboot
 UninstallKey    : 32
 
-Name            : Visual C++ Redistributable for Visual Studio 2019
-ProductCode     : {855e31d2-9031-46e1-b06d-c9d7777deefb}
-Version         : 14.28.29913.0
+Name            : Visual C++ Redistributable for Visual Studio 2022
+ProductCode     : {fa7f6d52-f85e-48ef-8f56-a37268aa5773}
+Version         : 14.30.30000.0
 URL             : https://www.visualstudio.com/downloads/
-Download        : https://aka.ms/vs/16/release/VC_redist.x64.exe
-Release         : 2019
+Download        : https://aka.ms/vs/17/release/VC_redist.x64.exe
+Release         : 2022
 Architecture    : x64
 Install         : /install /passive /norestart
 SilentInstall   : /install /quiet /norestart
-SilentUninstall : "%ProgramData%\Package Cache\{855e31d2-9031-46e1-b06d-c9d7777deefb}\VC_redist.x64.exe" /uninstall /quiet /noreboot
+SilentUninstall : "%ProgramData%\Package Cache\{fa7f6d52-f85e-48ef-8f56-a37268aa5773}\VC_redist.x64.exe" /uninstall /quiet /noreboot
 UninstallKey    : 32
 
 Name            : Visual C++ Redistributable for Visual Studio 2019
-ProductCode     : {03d1453c-7d5c-479c-afea-8482f406e036}
-Version         : 14.28.29913.0
+ProductCode     : {b7a2b241-3f54-4d7d-94d1-8ce0146e03c8}
+Version         : 14.30.30000.0
 URL             : https://www.visualstudio.com/downloads/
-Download        : https://aka.ms/vs/16/release/VC_redist.x86.exe
-Release         : 2019
+Download        : https://aka.ms/vs/17/release/VC_redist.x86.exe
+Release         : 2022
 Architecture    : x86
 Install         : /install /passive /norestart
 SilentInstall   : /install /quiet /norestart
-SilentUninstall : "%ProgramData%\Package Cache\{03d1453c-7d5c-479c-afea-8482f406e036}\VC_redist.x86.exe" /uninstall /quiet /noreboot
+SilentUninstall : "%ProgramData%\Package Cache\{b7a2b241-3f54-4d7d-94d1-8ce0146e03c8}\VC_redist.x86.exe" /uninstall /quiet /noreboot
 UninstallKey    : 32
 ```
 
@@ -64,7 +88,7 @@ Output from `Get-VcList` can be piped to `Save-VcRedist`, `Install-VcRedist`, `I
 
 ### Optional parameters
 
-* `Release` - Specifies the release (or version) of the redistributables to return (e.g. 2019, 2010, 2012, etc.)
+* `Release` - Specifies the release (or version) of the redistributables to return (e.g. 2022, 2019, 2010, 2012, etc.)
 * `Architecture` - Specifies the processor architecture to of the redistributables to return. Can be x86 or x64
 * `Export` - Defines the list of Visual C++ Redistributables to export - All, Supported or Unsupported Redistributables. Defaults to exporting the Supported Redistributables.
 * `Manifest` - An external JSON file that contains the details about the Visual C++ Redistributables. This must be in the expected format
@@ -79,7 +103,7 @@ To return Redistributables from the list of unsupported Redistributables or the 
 
 ## Filtering Output
 
-The output from `Get-VcList` can be filtered before sending to other functions. `Get-VcList` has the `-Release` parameter for filtering on the 2005, 2008, 2010, 2012, 2013, 2015, 2017 and 2019 releases of the Redistributables. Additionally, the `-Architecture` parameter can filter on x86 and x64 processor architectures.
+The output from `Get-VcList` can be filtered before sending to other functions. `Get-VcList` has the `-Release` parameter for filtering on the 2005, 2008, 2010, 2012, 2013, 2015, 2017, 2019 and 2022 releases of the Redistributables. Additionally, the `-Architecture` parameter can filter on x86 and x64 processor architectures.
 
 These parameters cannot be used with the `-Export` parameter. If you require filtering when exporting All, Supported or Unsuppported Redistributables, pipe the output to the `Where-Object` function.
 
@@ -91,10 +115,10 @@ Return the current list of supported Redistributables:
 Get-VcList
 ```
 
-`Get-VcList` does not return the 2015 and 2017 releases by default. To return specific releases and processor architectures from the supported list of Redistributables, the following example can be used:
+`Get-VcList` does not return the 2015, 2017 and 2019 releases by default. To return specific releases and processor architectures from the supported list of Redistributables, the following example can be used:
 
 ```powershell
-Get-VcList -Release 2010, 2012, 2013, 2017 -Architecture x64
+Get-VcList -Release 2012, 2013, 2017 -Architecture x64
 ```
 
 To return the complete list of available supported and unsupported Redistributables:

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,18 +19,31 @@ It is important to understand that Microsoft no longer supports and provides sec
 
 ## Unsupported Redistributables
 
-As at March 2021, the Unsupported list of Redistributables includes the following versions:
+As at November 2022, the Unsupported list of Redistributables includes the following versions:
 
-|Name                                                                      |Version       |
-|--------------------------------------------------------------------------|--------------|
-|Visual C++ 2005 Redistributable Package                                   |8.0.50727.42  |
-|Visual C++ 2005 SP1 Redistributable Package                               |8.0.56336     |
-|Visual C++ 2005 Service Pack 1 Redistributable Package ATL Security Update|8.0.59192     |
-|Visual C++ 2005 Service Pack 1 Redistributable Package MFC Security Update|8.0.61000     |
-|Visual C++ 2008 Redistributable Package                                   |9.0.21022     |
-|Visual C++ 2008 Feature Pack Redistributable Package                      |9.0.21022.218 |
-|Visual C++ 2008 Redistributable Package ATL Security Update               |9.0.30411     |
-|Visual C++ 2008 SP1 Redistributable Package                               |9.0.30729     |
-|Visual C++ 2008 Service Pack 1 Redistributable Package ATL Security Update|9.0.30729.4148|
-|Visual C++ 2008 Service Pack 1 Redistributable Package MFC Security Update|9.0.30729.6161|
-|Visual C++ Redistributable Packages for Visual Studio 2013                |12.0.30501.0  |
+| Name                                                                       | Version        |
+| -------------------------------------------------------------------------- | -------------- |
+| Visual C++ 2008 Service Pack 1 Redistributable Package MFC Security Update | 9.0.30729.6161 |
+| Visual C++ 2008 Service Pack 1 Redistributable Package MFC Security Update | 9.0.30729.6161 |
+| Visual C++ 2005 Service Pack 1 Redistributable Package MFC Security Update | 8.0.61000      |
+| Visual C++ 2005 Service Pack 1 Redistributable Package ATL Security Update | 8.0.59192      |
+| Visual C++ 2005 SP1 Redistributable Package                                | 8.0.56336      |
+| Visual C++ 2005 Redistributable Package                                    | 8.0.50727.42   |
+| Visual C++ 2005 Service Pack 1 Redistributable Package MFC Security Update | 8.0.61000      |
+| Visual C++ 2005 Service Pack 1 Redistributable Package ATL Security Update | 8.0.59192      |
+| Visual C++ 2005 SP1 Redistributable Package                                | 8.0.56336      |
+| Visual C++ 2005 Redistributable Package                                    | 8.0.50727.42   |
+| Visual C++ 2008 Redistributable Package                                    | 9.0.21022      |
+| Visual C++ 2008 Feature Pack Redistributable Package                       | 9.0.21022.218  |
+| Visual C++ 2008 Redistributable Package ATL Security Update                | 9.0.30411      |
+| Visual C++ 2008 SP1 Redistributable Package                                | 9.0.30729      |
+| Visual C++ 2008 Service Pack 1 Redistributable Package ATL Security Update | 9.0.30729.4148 |
+| Visual C++ 2008 Redistributable Package                                    | 9.0.21022      |
+| Visual C++ 2008 Feature Pack Redistributable Package                       | 9.0.21022.218  |
+| Visual C++ 2008 Redistributable Package ATL Security Update                | 9.0.30411      |
+| Visual C++ 2008 SP1 Redistributable Package                                | 9.0.30729      |
+| Visual C++ 2008 Service Pack 1 Redistributable Package ATL Security Update | 9.0.30729.4148 |
+| Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update | 10.0.40219.325 |
+| Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update | 10.0.40219.325 |
+| Visual C++ Redistributable Packages for Visual Studio 2013                 | 12.0.30501.0   |
+| Visual C++ Redistributable Packages for Visual Studio 2013                 | 12.0.30501.0   |

--- a/docs/save-vcredist.md
+++ b/docs/save-vcredist.md
@@ -36,14 +36,14 @@ $VcList = Get-VcList -Release 2013, 2019 -Architecture x86
 Save-VcRedist -VcList $VcList -Path C:\Redist
 ```
 
-Download the 2010, 2012, 2013, and 2019 Visual C++ Redistributables to C:\Redist.
+Download the 2012, 2013, and 2019 Visual C++ Redistributables to C:\Redist.
 
 ```powershell
-Save-VcRedist -VcList (Get-VcList -Release 2010, 2012, 2013, 2019) -Path C:\Redist
+Save-VcRedist -VcList (Get-VcList -Release 2012, 2013, 2019) -Path C:\Redist
 ```
 
-Downloads the 2010, 2012, 2013, and 2019 Visual C++ Redistributables to C:\Redist using the proxy server 'proxy.domain.local'
+Downloads the 2012, 2013, and 2019 Visual C++ Redistributables to C:\Redist using the proxy server 'proxy.domain.local'
 
 ```powershell
-Save-VcRedist -VcList (Get-VcList -Release 2010, 2012, 2013, 2019) -Path C:\Redist -Proxy proxy.domain.local
+Save-VcRedist -VcList (Get-VcList -Release 2012, 2013, 2019) -Path C:\Redist -Proxy proxy.domain.local
 ```

--- a/docs/uninstall-vcredist.md
+++ b/docs/uninstall-vcredist.md
@@ -13,7 +13,7 @@ None. If `Uninstall-VcRedist` is run without parameters, you will be prompted to
 ### Optional parameters
 
 * `Confirm` - `Uninstall-VcRedist` will not uninstall Redistributables by default. `-Confirm:$True` is required to enable `Uninstall-VcRedist` to uninstall the Redistributables.
-* `Release` - Specifies the release (or version) of the redistributables to uninstall (e.g. 2019, 2010, 2012, etc.)
+* `Release` - Specifies the release (or version) of the redistributables to uninstall (e.g. 2022, 2019, 2012, etc.)
 * `Architecture` - Specifies the processor architecture to of the redistributables to uninstall. Can be x86 or x64
 
 ## Examples

--- a/docs/versions.md
+++ b/docs/versions.md
@@ -37,4 +37,4 @@ VcRedist `3.0.281` includes the following Redistributables (supported and unsupp
 | 8.0.56336      | x86          | Visual C++ 2005 SP1 Redistributable Package                                |
 | 8.0.56336      | x64          | Visual C++ 2005 SP1 Redistributable Package                                |
 | 8.0.50727.42   | x86          | Visual C++ 2005 Redistributable Package                                    |
-| 8.0.50727.42   | x64          | Visual C++ 2005 Redistributable Package                                    |
+| 8.0.50727.42   | x64          | Visual C++ 2005 Redistributable Package                                    |

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -22,7 +22,7 @@ Function Test-VcDownloads {
     $Output = $False
     ForEach ($VcRedist in $VcList) {
         $folder = [System.IO.Path]::Combine((Resolve-Path -Path $Path), $VcRedist.Release, $VcRedist.Version, $VcRedist.Architecture)
-        $Target = Join-Path $Folder $(Split-Path -Path $VcRedist.Download -Leaf)
+        $Target = [System.IO.Path]::Combine($Folder, $(Split-Path -Path $VcRedist.Download -Leaf))
         If (Test-Path -Path $Target -PathType Leaf) {
             Write-Verbose "$($Target) - exists."
             $Output = $True
@@ -45,24 +45,32 @@ Else {
 }
 Write-Host -ForegroundColor Cyan "`tDownload dir: $downloadDir."
 
+# VcRedist manifest counts
+$VcCount = @{
+    "Default"     = 6
+    "All"         = 34
+    "Supported"   = 10
+    "Unsupported" = 24
+}
+
 #region Function tests
 Describe 'Get-VcList' -Tag "Get" {
     Context 'Return built-in manifest' {
         It 'Given no parameters, it returns supported Visual C++ Redistributables' {
             $VcList = Get-VcList
-            $VcList | Should -HaveCount 6
+            $VcList | Should -HaveCount $VcCount.Default
         }
         It 'Given valid parameter -Export All, it returns all Visual C++ Redistributables' {
-            $VcList = Get-VcList -Export All
-            $VcList | Should -HaveCount 34
+            $VcList = Get-VcList -Export "All"
+            $VcList | Should -HaveCount $VcCount.All
         }
         It 'Given valid parameter -Export Supported, it returns all Visual C++ Redistributables' {
-            $VcList = Get-VcList -Export Supported
-            $VcList | Should -HaveCount 10
+            $VcList = Get-VcList -Export "Supported"
+            $VcList | Should -HaveCount $VcCount.Supported
         }
         It 'Given valid parameter -Export Unsupported, it returns unsupported Visual C++ Redistributables' {
-            $VcList = Get-VcList -Export Unsupported
-            $VcList | Should -HaveCount 24
+            $VcList = Get-VcList -Export "Unsupported"
+            $VcList | Should -HaveCount $VcCount.Unsupported
         }
     }
     Context 'Validate Get-VcList array properties' {
@@ -85,19 +93,19 @@ Describe 'Get-VcList' -Tag "Get" {
     }
     Context 'Return external manifest' {
         It 'Given valid parameter -Path, it returns Visual C++ Redistributables from an external manifest' {
-            $Json = Join-Path -Path $ProjectRoot -ChildPath "Redists.json"
+            $Json = [System.IO.Path]::Combine($ProjectRoot, "Redists.json")
             Export-VcManifest -Path $Json
             $VcList = Get-VcList -Path $Json
-            $VcList.Count | Should -BeGreaterOrEqual 8
+            $VcList.Count | Should -BeGreaterOrEqual $VcCount.Default
         }
     }
     Context 'Test fail scenarios' {
         It 'Given an JSON file that does not exist, it should throw an error' {
-            $Json = Join-Path -Path $ProjectRoot -ChildPath "RedistsFail.json"
+            $Json = [System.IO.Path]::Combine($ProjectRoot, "RedistsFail.json")
             { Get-VcList -Path $Json } | Should Throw
         }
         It 'Given an invalid JSON file, should throw an error on read' {
-            $Json = Join-Path -Path $ProjectRoot -ChildPath "README.MD"
+            $Json = [System.IO.Path]::Combine($ProjectRoot, "README.MD")
             { Get-VcList -Path $Json } | Should Throw
         }
     }
@@ -106,22 +114,22 @@ Describe 'Get-VcList' -Tag "Get" {
 Describe 'Export-VcManifest' -Tag "Export" {
     Context 'Export manifest' {
         It 'Given valid parameter -Path, it exports an JSON file' {
-            $Json = Join-Path -Path $ProjectRoot -ChildPath "Redists.json"
+            $Json = [System.IO.Path]::Combine($ProjectRoot, "Redists.json")
             Export-VcManifest -Path $Json
             Test-Path -Path $Json | Should -Be $True
         }
     }
     Context 'Export and read manifest' {
         It 'Given valid parameter -Path, it exports an JSON file' {
-            $Json = Join-Path -Path $ProjectRoot -ChildPath "Redists.json"
+            $Json = [System.IO.Path]::Combine($ProjectRoot, "Redists.json")
             Export-VcManifest -Path $Json
             $VcList = Get-VcList -Path $Json
-            $VcList.Count | Should -BeGreaterOrEqual 8
+            $VcList.Count | Should -BeGreaterOrEqual $VcCount.Default
         }
     }
     Context 'Test fail scenarios' {
         It 'Given an invalid path, it should throw an error' {
-            { Export-VcManifest -Path (Join-Path -Path (Join-Path -Path $ProjectRoot -ChildPath "Temp") -ChildPath "Temp.json") } | Should Throw
+            { Export-VcManifest -Path [System.IO.Path]::Combine($ProjectRoot, "Temp", "Temp.json") } | Should Throw
         }
     }
 }
@@ -130,7 +138,7 @@ Describe 'Save-VcRedist' -Tag "Save" {
     Context 'Download Redistributables' {
         It 'Downloads supported Visual C++ Redistributables' {
             If (Test-Path -Path $downloadDir -ErrorAction "SilentlyContinue") {
-                $Path = Join-Path -Path $downloadDir -ChildPath "VcDownload"
+                $Path = [System.IO.Path]::Combine($downloadDir, "VcDownload")
                 If (!(Test-Path $Path)) { New-Item $Path -ItemType Directory -Force > $Null }
                 $VcList = Get-VcList
                 Write-Host "`tDownloading VcRedists." -ForegroundColor Cyan
@@ -142,7 +150,7 @@ Describe 'Save-VcRedist' -Tag "Save" {
             }
         }
         It 'Returns an expected object type to the pipeline' {
-            $Path = Join-Path -Path $downloadDir -ChildPath "VcDownload"
+            $Path = [System.IO.Path]::Combine($downloadDir, "VcDownload")
             If (Test-Path -Path $Path) { Remove-Item -Path $Path -Recurse -Force }
             New-Item -Path $Path -ItemType Directory -Force > $Null
             
@@ -155,8 +163,8 @@ Describe 'Save-VcRedist' -Tag "Save" {
     Context "Test pipeline support" {
         It "Should not throw when passed via pipeline with no parameters" {
             If (Test-Path -Path $downloadDir -ErrorAction "SilentlyContinue") {
-                New-Item -Path (Join-Path -Path $downloadDir -ChildPath "VcTest") -ItemType Directory -ErrorAction "SilentlyContinue" > $Null
-                Push-Location -Path (Join-Path -Path $downloadDir -ChildPath "VcTest")
+                New-Item -Path ([System.IO.Path]::Combine($downloadDir, "VcTest")) -ItemType Directory -ErrorAction "SilentlyContinue" > $Null
+                Push-Location -Path ([System.IO.Path]::Combine($downloadDir, "VcTest"))
                 Write-Host "`tDownloading VcRedists." -ForegroundColor Cyan
                 { Get-VcList | Save-VcRedist } | Should -Not -Throw
                 Pop-Location
@@ -168,7 +176,7 @@ Describe 'Save-VcRedist' -Tag "Save" {
     }
     Context 'Test fail scenarios' {
         It 'Given an invalid path, it should throw an error' {
-            { Save-VcRedist -Path (Join-Path -Path $ProjectRoot -ChildPath "Temp") } | Should -Throw
+            { Save-VcRedist -Path ([System.IO.Path]::Combine($ProjectRoot, "Temp")) } | Should -Throw
         }
     }
 }
@@ -177,7 +185,7 @@ Describe 'Install-VcRedist' -Tag "Install" {
     Context 'Install Redistributables' {
         If (Test-Path -Path $downloadDir -ErrorAction "SilentlyContinue") {
             $VcRedists = Get-VcList
-            $Path = Join-Path -Path $downloadDir -ChildPath "VcDownload"
+            $Path = [System.IO.Path]::Combine($downloadDir, "VcDownload")
             Write-Host "`tInstalling VcRedists." -ForegroundColor Cyan
             $Installed = Install-VcRedist -VcList $VcRedists -Path $Path -Silent
             ForEach ($VcRedist in $VcRedists) {
@@ -211,7 +219,7 @@ If (($Null -eq $PSVersionTable.OS) -or ($PSVersionTable.OS -like "*Windows*")) {
     Describe 'Uninstall-VcRedist' -Tag "Uninstall" {
         Context 'Uninstall VcRedists' {
             Write-Host "`tUninstalling VcRedists." -ForegroundColor Cyan
-            { Uninstall-VcRedist -Release 2010, 2013 -Confirm:$False } | Should -Not -Throw
+            { Uninstall-VcRedist -Release "2012", "2013" -Confirm:$False } | Should -Not -Throw
         }
     }
 }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -47,8 +47,8 @@ Write-Host -ForegroundColor Cyan "`tDownload dir: $downloadDir."
 
 # VcRedist manifest counts
 $VcCount = @{
-    "Default"     = 6
-    "All"         = 34
+    "Default"     = 8
+    "All"         = 36
     "Supported"   = 10
     "Unsupported" = 24
 }

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -49,7 +49,7 @@ Write-Host -ForegroundColor Cyan "`tDownload dir: $downloadDir."
 $VcCount = @{
     "Default"     = 8
     "All"         = 36
-    "Supported"   = 10
+    "Supported"   = 12
     "Unsupported" = 24
 }
 
@@ -227,7 +227,7 @@ If (($Null -eq $PSVersionTable.OS) -or ($PSVersionTable.OS -like "*Windows*")) {
 
 #region Manifest test
 # Get an array of VcRedists from the current manifest and the installed VcRedists
-$Release = "2019"
+$Release = "2022"
 Write-Host -ForegroundColor Cyan "`tGetting manifest from: $VcManifest."
 $CurrentManifest = Get-Content -Path $VcManifest | ConvertFrom-Json
 $InstalledVcRedists = Get-InstalledVcRedist

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -50,7 +50,7 @@ Describe 'Get-VcList' -Tag "Get" {
     Context 'Return built-in manifest' {
         It 'Given no parameters, it returns supported Visual C++ Redistributables' {
             $VcList = Get-VcList
-            $VcList | Should -HaveCount 8
+            $VcList | Should -HaveCount 6
         }
         It 'Given valid parameter -Export All, it returns all Visual C++ Redistributables' {
             $VcList = Get-VcList -Export All
@@ -58,11 +58,11 @@ Describe 'Get-VcList' -Tag "Get" {
         }
         It 'Given valid parameter -Export Supported, it returns all Visual C++ Redistributables' {
             $VcList = Get-VcList -Export Supported
-            $VcList | Should -HaveCount 12
+            $VcList | Should -HaveCount 10
         }
         It 'Given valid parameter -Export Unsupported, it returns unsupported Visual C++ Redistributables' {
             $VcList = Get-VcList -Export Unsupported
-            $VcList | Should -HaveCount 22
+            $VcList | Should -HaveCount 24
         }
     }
     Context 'Validate Get-VcList array properties' {

--- a/tests/PublicFunctions.Tests.ps1
+++ b/tests/PublicFunctions.Tests.ps1
@@ -47,10 +47,10 @@ Write-Host -ForegroundColor Cyan "`tDownload dir: $downloadDir."
 
 # VcRedist manifest counts
 $VcCount = @{
-    "Default"     = 8
-    "All"         = 36
+    "Default"     = 6
     "Supported"   = 12
     "Unsupported" = 24
+    "All"         = 36
 }
 
 #region Function tests


### PR DESCRIPTION
* Adds support for Visual C++ Redistributable for Visual Studio 2022, version `14.30.30704.0`
* Moves the `Visual C++ 2010 Service Pack 1 Redistributable Package MFC Security Update` to the unsupported list of Redistributables