### PR TITLE
Development

### DIFF
--- a/.github/workflows/validate-module.yml
+++ b/.github/workflows/validate-module.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Upload to Codecov
         id: codecov
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./CodeCoverage-${{ matrix.os }}.xml

--- a/VcRedist/Private/Import-MdtModule.ps1
+++ b/VcRedist/Private/Import-MdtModule.ps1
@@ -32,14 +32,19 @@ function Import-MdtModule {
     $MdtInstallDir = Resolve-Path -Path $MdtReg.Install_Dir
     $MdtModule = [System.IO.Path]::Combine($MdtInstallDir, "bin", "MicrosoftDeploymentToolkit.psd1")
     if (Test-Path -Path $mdtModule -ErrorAction "SilentlyContinue") {
-        Write-Verbose -Message "Loading MDT module from: $MdtInstallDir."
-        $params = @{
-            Name        = $MdtModule
-            ErrorAction = "Stop"
-            Force       = if ($Force) { $true } else { $false }
+        try {
+            Write-Verbose -Message "Loading MDT module from: $MdtInstallDir."
+            $params = @{
+                Name        = $MdtModule
+                ErrorAction = "Stop"
+                Force       = if ($Force) { $true } else { $false }
+            }
+            Import-Module @params
+            Write-Output -InputObject $true
         }
-        Import-Module @params
-        Write-Output -InputObject $true
+        catch {
+            throw $_
+        }
     }
     else {
         $Msg = "Unable to find the MDT PowerShell module at $MdtModule. Ensure the Microsoft Deployment Toolkit is installed and try again."

--- a/VcRedist/Private/New-MdtDrive.ps1
+++ b/VcRedist/Private/New-MdtDrive.ps1
@@ -28,27 +28,19 @@ function New-MdtDrive {
     # Set a description to be applied to the new MDT drive
     $Description = "MDT drive created by $($MyInvocation.MyCommand)"
 
-    if ($mdtDrives = Get-MdtPersistentDrive | Where-Object { ($_.Path -eq $Path) -and ($_.Description -eq $Description) }) {
-        Write-Verbose -Message "Found MDT drive: $($mdtDrives[0].Name)"
-        $output = $mdtDrives[0].Name
-    }
-    else {
-        if ($PSCmdlet.ShouldProcess("$($Drive): to $($Path)", "Mapping")) {
-            $params = @{
-                Name        = $Drive
-                PSProvider  = "MDTProvider"
-                Root        = $Path
-                #NetworkPath = $Path
-                Description = $Description
-                ErrorAction = "Stop"
-            }
-            New-PSDrive @params | Add-MDTPersistentDrive
-
-            # Return the MDT drive name
-            $psDrive = Get-MdtPersistentDrive | Where-Object { $_.Path -eq $Path -and $_.Name -eq $Drive }
-            Write-Verbose -Message "Found: $($psDrive.Name)"
-            $output = $psDrive.Name
+    if ($PSCmdlet.ShouldProcess("$($Drive): to $($Path)", "Mapping")) {
+        $params = @{
+            Name        = $Drive
+            PSProvider  = "MDTProvider"
+            Root        = $Path
+            Description = $Description
+            ErrorAction = "Stop"
         }
+        New-PSDrive @params | Add-MDTPersistentDrive
+
+        # Return the MDT drive name
+        $psDrive = Get-MdtPersistentDrive | Where-Object { $_.Path -eq $Path -and $_.Name -eq $Drive }
+        Write-Verbose -Message "Found: $($psDrive.Name)"
+        Write-Output -InputObject $psDrive.Name
     }
-    Write-Output -InputObject $output
 }

--- a/VcRedist/Public/Import-VcMdtApplication.ps1
+++ b/VcRedist/Public/Import-VcMdtApplication.ps1
@@ -118,10 +118,10 @@ function Import-VcMdtApplication {
             # Set variables
             Write-Verbose -Message "processing: '$($VcRedist.Name) $($VcRedist.Architecture)'."
             $supportedPlatform = if ($VcRedist.Architecture -eq "x86") {
-                @("All x86 Windows 7 and Newer", "All x64 Windows 7 and Newer")
+                $null
             }
             else {
-                @("All x64 Windows 7 and Newer")
+                @("All x64 Windows 10 Client", "All x64 Windows Server 10")
             }
 
             # Check for existing application by matching current VcRedist

--- a/VcRedist/VisualCRedistributables.json
+++ b/VcRedist/VisualCRedistributables.json
@@ -132,8 +132,8 @@
                       },
                       {
                           "Name":  "Visual C++ Redistributable for Visual Studio 2022",
-                          "ProductCode":  "{8bdfe669-9705-4184-9368-db9ce581e0e7}",
-                          "Version":  "14.36.32532.0",
+                          "ProductCode":  "{1de5e707-82da-4db6-b810-5d140cc4cbb3}",
+                          "Version":  "14.38.33130.0",
                           "URL":  "https://www.visualstudio.com/downloads/",
                           "URI":  "https://aka.ms/vs/17/release/VC_redist.x64.exe",
                           "Release":  "2022",
@@ -145,8 +145,8 @@
                       },
                       {
                           "Name":  "Visual C++ Redistributable for Visual Studio 2022",
-                          "ProductCode":  "{410c0ee1-00bb-41b6-9772-e12c2828b02f}",
-                          "Version":  "14.36.32532.0",
+                          "ProductCode":  "{2cfeba4a-21f8-4ea7-9927-c5a5c6f13cc9}",
+                          "Version":  "14.38.33130.0",
                           "URL":  "https://www.visualstudio.com/downloads/",
                           "URI":  "https://aka.ms/vs/17/release/VC_redist.x86.exe",
                           "Release":  "2022",

--- a/VcRedist/VisualCRedistributables.json
+++ b/VcRedist/VisualCRedistributables.json
@@ -106,8 +106,8 @@
                       },
                       {
                           "Name":  "Visual C++ Redistributable for Visual Studio 2019",
-                          "ProductCode":  "{2c673fb6-3e65-4751-965d-33d30b68a8a6}",
-                          "Version":  "14.29.30139.0",
+                          "ProductCode":  "{9057ceb3-ab14-4d3a-aa99-38d2d660e604}",
+                          "Version":  "14.29.30153.0",
                           "URL":  "https://www.visualstudio.com/downloads/",
                           "URI":  "https://aka.ms/vs/16/release/VC_redist.x64.exe",
                           "Release":  "2019",
@@ -119,8 +119,8 @@
                       },
                       {
                           "Name":  "Visual C++ Redistributable for Visual Studio 2019",
-                          "ProductCode":  "{8d5fdf81-7022-423f-bd8b-b513a1050ae1}",
-                          "Version":  "14.29.30139.0",
+                          "ProductCode":  "{e3aefa8b-a2ea-42b8-a384-95f2ff6df681}",
+                          "Version":  "14.29.30153.0",
                           "URL":  "https://www.visualstudio.com/downloads/",
                           "URI":  "https://aka.ms/vs/16/release/VC_redist.x86.exe",
                           "Release":  "2019",


### PR DESCRIPTION
* Fix an issue where Redistributables imported into MDT do not install #144 
* Fix an issue when importing the Redistributables into an MDT deployment share #
* Update Redistributables `2019` to `14.29.30153.0`
* Update Redistributables `2022` to `14.38.33130.0`