### PR TITLE
Correct VC++ 2013 12.0.30501.0 x86 Product Code

### DIFF
--- a/VcRedist/VisualCRedistributables.json
+++ b/VcRedist/VisualCRedistributables.json
@@ -290,7 +290,7 @@
                         },
                         {
                             "Name":  "Visual C++ Redistributable Packages for Visual Studio 2013",
-                            "ProductCode":  "{050d4fc8-5d48-4b8f-8972-47c82c46020f}",
+                            "ProductCode":  "{f65db027-aff3-4070-886a-0d87064aabb1}",
                             "Version":  "12.0.30501.0",
                             "URL":  "https://www.microsoft.com/en-us/download/details.aspx?id=40784",
                             "URI":  "https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe",


### PR DESCRIPTION
# Description

The product code for VC++ 2013 12.0.30501.0  x86 is {f65db027-aff3-4070-886a-0d87064aabb1} . It looks like there was a copy/paste mistake because it was set to the same code as the x64 installer.

## Motivation and Context

The detection rules for SCCM and Intune incorrectly check for the x64 product code instead of the x86 product code.

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/3c8fa868-032f-4203-b528-e747e01a9183)
Winget's manifest file: https://github.com/microsoft/winget-pkgs/blob/master/manifests/m/Microsoft/VCRedist/2013/x86/12.0.30501.0/Microsoft.VCRedist.2013.x86.installer.yaml

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
