### PR TITLE
Fix ARM64 detection

### DIFF
--- a/VcRedist/Public/Get-InstalledVcRedist.ps1
+++ b/VcRedist/Public/Get-InstalledVcRedist.ps1
@@ -25,7 +25,10 @@ function Get-InstalledVcRedist {
 
     # Add Architecture property to each entry
     Write-Verbose -Message "Add Architecture property to output object."
-    $VcRedists | ForEach-Object { if ($_.Name -contains "x64") { $_ | Add-Member -NotePropertyName "Architecture" -NotePropertyValue "x64" } }
+    $VcRedists | ForEach-Object { 
+        if ($_.Name -like "*x64*") { $_.Architecture = "x64" }
+        if ($_.Name -like "*Arm64*") { $_.Architecture = "ARM64" }
+    }
 
     # Write the installed VcRedists to the pipeline
     Write-Output -InputObject $VcRedists

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.523
+
+* Fixes x64 Redistributable Architecture detection fallback
+* Adds ARM64 Redistributable Architecture detection fallback
+  
 ## 4.1.522
 
 * Update VcRedist `2022` to `14.44.35211.0`


### PR DESCRIPTION
# Description

On Windows 11 ARM machines with Arm64 versions of VC2022 installed, Get-InstalledVCRedist shows the Architecture as x86.

```
Name                                                               Version       Architecture Release
----                                                               -------       ------------ -------
Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.44.35211 14.44.35211.0 x64          2022
Microsoft Visual C++ 2022 Redistributable (Arm64) - 14.44.35211    14.44.35211.0 x86          2022
Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.44.35211 14.44.35211.0 x86          2022
```
This causes problems when trying to match installed versions with 'available' versions, meaning ARM64 versions are never detected or updated.

This patch has a fix.

The 'contains' method that existed previously would never match any names in a string, whereas 'like' does. This meant that redistributables with 'x64' in the name weren't having their architecture overwritten with 'x64' as intended. That didn't seem to be an issue for me, and the architecture was already set to x64 despite this check being broken.

I added an extra check for Arm64 redistributables here, so anything with 'Arm64' in the 'name' will have its architecture set to 'ARM64' as well.

After the patch, this is the result:


```
Name                                                               Version       Architecture Release
----                                                               -------       ------------ -------
Microsoft Visual C++ 2015-2022 Redistributable (x64) - 14.44.35211 14.44.35211.0 x64          2022
Microsoft Visual C++ 2022 Redistributable (Arm64) - 14.44.35211    14.44.35211.0 ARM64        2022
Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.44.35211 14.44.35211.0 x86          2022
```

This is my first attempt at using GIT - go easy on me please! Hopefully I've done everything correctly?

## Related Issue

https://github.com/aaronparker/vcredist/issues/191

## Motivation and Context

ARM Machines with ARM64 specific versions of VC2022 were not being updated, since Get-InstalledVCRedist was not reporting the architecture correctly.

## How Has This Been Tested?

I tested this on an ARM machine containing x86 and ARM64 VC2022 runtimes. Before the patch, Get-InstalledVCRedist showed 2x x86 versions being installed. After the patch, it now correctly shows one as ARM64 architecture.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
